### PR TITLE
Fixing pacman install command

### DIFF
--- a/buildblendercam_on_linux.sh
+++ b/buildblendercam_on_linux.sh
@@ -78,7 +78,7 @@ do
 	        shift
             ;;
 		--pacman)
-			PACKAGE_MANAGER_INSTALL_COMMAND=' pacman -S install '
+			PACKAGE_MANAGER_INSTALL_COMMAND=' pacman -S '
 	        shift
             ;;
 		--yaourt)


### PR DESCRIPTION
Fixing the install command for Arch Linux users.

pacman -S is the proper install command.

Thanks for your work in getting this together though!
